### PR TITLE
Add a failing test that succeeds with unix patch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2470,8 +2470,8 @@
       }
     },
     "node_modules/diffcalculia-ts": {
-      "version": "1.0.3",
-      "resolved": "git+ssh://git@github.com/createthis/diffcalculia-ts.git#9e3ed7df9cbf1c8bd6a417fdd082ff37ab03bdd1",
+      "version": "1.0.4",
+      "resolved": "git+ssh://git@github.com/createthis/diffcalculia-ts.git#2f294adcbb6f8e143dffbe310f08340d883699d8",
       "dependencies": {
         "tsx": "^4.19.4"
       },

--- a/tests/fixtures/leading_and_trailing_whitespace/expected.txt
+++ b/tests/fixtures/leading_and_trailing_whitespace/expected.txt
@@ -1,0 +1,18 @@
+
+
+Common Header
+Section 1
+Context Line
+Context Line
+Modify This
+Modified Successfully
+Context Line
+Context Line
+Section 2
+Context Line
+Context Line
+Modify This
+Context Line
+Context Line
+Common Footer
+

--- a/tests/fixtures/leading_and_trailing_whitespace/original.txt
+++ b/tests/fixtures/leading_and_trailing_whitespace/original.txt
@@ -1,0 +1,17 @@
+
+
+Common Header
+Section 1
+Context Line
+Context Line
+Modify This
+Context Line
+Context Line
+Section 2
+Context Line
+Context Line
+Modify This
+Context Line
+Context Line
+Common Footer
+

--- a/tests/fixtures/leading_and_trailing_whitespace/patch.diff
+++ b/tests/fixtures/leading_and_trailing_whitespace/patch.diff
@@ -1,0 +1,15 @@
+
+
+
+--- ambiguous_context.txt
++++ ambiguous_context.txt
+@@ -3,6 +3,7 @@
+ Context Line
+ Context Line
+ Modify This
++Modified Successfully
+ Context Line
+ Context Line
+ Section 2
+
+

--- a/tests/patch.test.ts
+++ b/tests/patch.test.ts
@@ -78,6 +78,23 @@ describe("patch", () => {
     await expect(patch(diff, outFixturePath)).rejects.toThrow('Unknown line 11 "});"');
   });
 
+
+  it("apply patch with leading and trailing whitespace", async () => {
+    const originalPath = path.join(fixturesPath, "leading_and_trailing_whitespace/original.txt");
+    const patchPath = path.join(fixturesPath, "leading_and_trailing_whitespace/patch.diff");
+    const expectFixturePath = path.join(fixturesPath, "leading_and_trailing_whitespace/expected.txt");
+    const base = await fs.readFile(originalPath, "utf8");
+    await fs.writeFile(outFixturePath, base, "utf8");
+    const diff = await fs.readFile(patchPath, "utf8");
+
+    const exp = await fs.readFile(expectFixturePath, "utf8");
+    const result = await patch(diff, outFixturePath);
+    expect(result).not.toBe(false);
+    const out = await fs.readFile(outFixturePath, "utf8");
+    expect(out).toBe(exp);
+    expect(result).toBe(diff);
+  });
+
   describe('when verbose is true', () => {
     it("applies a well-formed diff", async () => {
       const diff = await fs.readFile(changeFixturePath, "utf8");


### PR DESCRIPTION
This succeeds on the CLI if I use *nix `patch`:

```bash
(base) jesse@Jesses-MacBook-Pro leading_and_trailing_whitespace % cp original.txt ambiguous_context.txt
(base) jesse@Jesses-MacBook-Pro leading_and_trailing_whitespace % patch -p1 <patch.diff            
patching file ambiguous_context.txt
(base) jesse@Jesses-MacBook-Pro leading_and_trailing_whitespace %
```